### PR TITLE
Update ConfigForm.php for D9 compatibility

### DIFF
--- a/src/Form/ConfigForm.php
+++ b/src/Form/ConfigForm.php
@@ -227,7 +227,7 @@ class ConfigForm extends ConfigFormBase {
    * @param \Drupal\Core\Form\FormStateInterface $form_state
    */
   public function CustomSubmit(array &$form, FormStateInterface $form_state) {
-    drupal_set_message("Custom Submit triggered");
+    \Drupal::messenger()->addStatus("Custom Submit triggered");
   }
 
   /**


### PR DESCRIPTION
drupal_set_message() is deprecated in D9.